### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/sipubot/RS-simple-scraper/security/code-scanning/1](https://github.com/sipubot/RS-simple-scraper/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimum required scopes to the `GITHUB_TOKEN`. For a workflow that just checks out the repository and runs `cargo build` and `cargo test`, read-only access to repository contents is sufficient, so `contents: read` at the workflow root is appropriate. This applies the same restricted permissions to all jobs that don’t override them.

Concretely, in `.github/workflows/rust.yml`, add a top-level `permissions:` section after the `on:` block (before `env:`) and set `contents: read`. This avoids changing any behavior of the existing steps: `actions/checkout@v3` works with `contents: read`, and the Rust commands run locally without additional permissions. No imports or other code changes are required, only the YAML modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
