### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/sipubot/RS-simple-scraper/security/code-scanning/2](https://github.com/sipubot/RS-simple-scraper/security/code-scanning/2)

To fix the problem, explicitly define a `permissions` block that grants only the scopes required for this release job. This job needs to read the repository (for checkout) and write tags/commits (`git push origin --follow-tags`), which requires `contents: write`. It does not appear to need other scopes such as `issues`, `pull-requests`, or `packages`, so those can be omitted.

The best fix with minimal functional change is to add a `permissions` section at the job level under `jobs.release`, so it only applies to this workflow’s release job. In `.github/workflows/release.yml`, under the `release:` job and before `runs-on: ubuntu-latest`, add:

```yaml
    permissions:
      contents: write
```

This explicitly documents and constrains the `GITHUB_TOKEN` permissions to what is necessary for pushing tags and any release commits, without affecting other workflows.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
